### PR TITLE
Allow managing of connection and defining models without first connecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ You can configure where Klein will put the models and migrations in your `packag
 The easiest init is:
 
 ```javascript
-// Assumes that process.env.DATABASE_URL is set
+// Assumes that process.env.DATABASE_URL is set and automatically connects 
+// to the database
 const Klein = require('klein/auto');
 ```
 
@@ -66,10 +67,26 @@ Or, if you already have an instanciated `knex` object:
 const Klein = require('klein').connect(knex);
 ```
 
-Then you can define a model:
+You can define models before connecting:
 
 ```javascript
+const Klein = require('klein');
 const Users = Klein.model('users');
+```
+
+Be sure to call `.connect()` before using the model:
+
+```javascript
+const Klein = require('klein');
+const Users = Klein.models('users');
+
+// Would throw an error before connecting
+// Users.where({ email: 'test@test.com' });
+
+Klein.connect();
+
+// No errors once connected
+Users.where({ email: 'test@test.com' });
 ```
 
 A bigger example:

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ class Klein {
         } else {
             this.knex = database_url_or_knex;
         }
+
+        return this;
     }
     
     model (table_name, args) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ const Model = require('./model');
 
 
 class Klein {
-    constructor (database_url_or_knex, client) {
+    constructor () {
+        this.models = {};
+    }
+
+    connect(database_url_or_knex, client) {
         if (database_url_or_knex instanceof String || typeof database_url_or_knex == "undefined") {
             const default_database_url = process.env.NODE_ENV == "test" ? process.env.TEST_DATABASE_URL : process.env.DATABASE_URL;
             
@@ -18,26 +22,13 @@ class Klein {
         } else {
             this.knex = database_url_or_knex;
         }
-        
-        this.models = {};
     }
-    
-    
-    static connect (database_url_or_knex, client, force_new_connection) {
-        if (force_new_connection || typeof Klein.instance === "undefined") {
-            Klein.instance = new Klein(database_url_or_knex, client);
-        }
-        
-        return Klein.instance;
-    }
-    
     
     model (table_name, args) {
         // If we already know about this model and no args are given then return the previously defined model
         if (typeof args === "undefined" && typeof this.models[table_name] !== "undefined") return this.models[table_name];
         
         args = Object.assign({}, {
-            knex: this.knex,
             klein: this
         }, args);
         
@@ -56,9 +47,12 @@ class Klein {
     
     
     transaction (handler) {
+        if (!this.knex) throw new Error('Klein must be connected (klein.connect()) before creating a transaction')
+
         return this.knex.transaction(handler);
     }
 }
 
+const default_instance = new Klein()
 
-module.exports = Klein;
+module.exports = default_instance;

--- a/index.js
+++ b/index.js
@@ -54,5 +54,8 @@ class Klein {
 }
 
 const default_instance = new Klein()
+default_instance.create = () => {
+    return new Klein()
+}
 
 module.exports = default_instance;

--- a/model.js
+++ b/model.js
@@ -6,7 +6,6 @@ const uuid = require('uuid/v4');
 class Model {
     constructor (table_name, args) {
         this.table_name = table_name;
-        this._knex = args.knex;
         this.klein = args.klein;
         this.args = args;
         
@@ -16,12 +15,6 @@ class Model {
             created_at: 'created_at',
             updated_at: 'updated_at'
         }, timestamps);
-        
-        if (args.default_scope) {
-            this.query = args.default_scope;
-        } else {
-            this.query = this._knex(this.table_name).select();
-        }
         
         this.defaults = Object.assign({}, {
             id: this.klein.uuid
@@ -63,15 +56,29 @@ class Model {
         });
     }
     
-    
     knex (table, options) {
+        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before a model has access to Knex')
+
         if (options && options.transaction) {
             return this._knex(table).transacting(options.transaction);
         } else {
             return this._knex(table);
         }
     }
-    
+
+    has_knex () {
+        return this.klein && this.klein.knex
+    }
+
+    query() {
+        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before querying a model')
+        
+        if (this.args.default_scope) {
+            return this.args.default_scope;
+        } else {
+            return this.knex(this.table_name).select();
+        }
+    }
     
     create (properties, options) {
         if (typeof options === "undefined") options = {};
@@ -94,6 +101,8 @@ class Model {
     
     
     destroy (model, options) {
+        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before destroying a model')
+
         return new Promise((resolve, reject) => {
             this.knex(this.table_name).where({ id: model.get('id') }).del().then(() => {
                 // Check over dependent has_many (and has_and_belongs_to_many join) relations
@@ -120,6 +129,8 @@ class Model {
     
     
     save (model, options) {
+        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before saving a model')
+
         if (typeof options === "undefined") options = {};
         
         let properties = model.toJS ? model.toJS() : Object.assign({}, model);
@@ -186,7 +197,7 @@ class Model {
     
     where () {
         const args = Array.from(arguments);
-        let query = this.query.clone();
+        let query = this.query().clone();
         
         if (args.length == 1) {
             query = query.where(args[0]);
@@ -199,37 +210,37 @@ class Model {
     
     
     whereIn (column, array) {
-        let query = this.query.clone().whereIn(column, array);
+        let query = this.query().clone().whereIn(column, array);
         return this._chain(query);
     }
     
     
     whereNotIn (column, array) {
-        let query = this.query.clone().whereNotIn(column, array);
+        let query = this.query().clone().whereNotIn(column, array);
         return this._chain(query);
     }
     
     
     whereNull (column) {
-        let query = this.query.clone().whereNull(column);
+        let query = this.query().clone().whereNull(column);
         return this._chain(query);
     }
     
     
     whereNotNull (column) {
-        let query = this.query.clone().whereNotNull(column);
+        let query = this.query().clone().whereNotNull(column);
         return this._chain(query);
     }
     
     
     include () {
         this.args._included_relations = Array.from(arguments);
-        return this._chain(this.query.clone());
+        return this._chain(this.query().clone());
     }
     
     
     first (options) {
-        let query = this.query.clone();
+        let query = this.query().clone();
         
         if (options && options.transaction) {
             query = query.transacting(options.transaction);
@@ -248,7 +259,7 @@ class Model {
     
     
     all (options) {
-        let query = this.query.clone();
+        let query = this.query().clone();
         
         if (options && options.transaction) {
             query = query.transacting(options.transaction);
@@ -265,7 +276,7 @@ class Model {
     
     
     delete (options) {
-        let query = this.query.clone();
+        let query = this.query().clone();
         
         if (options && options.transaction) {
             query = query.transacting(options.transaction);
@@ -278,7 +289,7 @@ class Model {
     page (n, per_page) {
         if (typeof per_page === "undefined") per_page = 20;
         
-        let query = this.query.clone().limit(per_page);
+        let query = this.query().clone().limit(per_page);
         
         if (typeof per_page !== "undefined") {
             query = query.offset((n - 1) * per_page);
@@ -290,7 +301,7 @@ class Model {
     
     order () {
         const args = Array.from(arguments);
-        let query = this.query.clone();
+        let query = this.query().clone();
         
         if (args.length == 1) {
             query = query.orderByRaw(args[0]);
@@ -354,7 +365,7 @@ class Model {
     
     
     toString () {
-        return this.query.toString();
+        return this.query().toString();
     }
     
     

--- a/model.js
+++ b/model.js
@@ -57,7 +57,7 @@ class Model {
     }
     
     knex (table, options) {
-        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before a model has access to Knex')
+        if (!this.hasKnex()) throw new Error('Klein must be connected (klein.connect()) before a model has access to Knex')
 
         if (options && options.transaction) {
             return this.klein.knex(table).transacting(options.transaction);
@@ -66,12 +66,12 @@ class Model {
         }
     }
 
-    has_knex () {
+    hasKnex () {
         return this.klein && this.klein.knex
     }
 
     query() {
-        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before querying a model')
+        if (!this.hasKnex()) throw new Error('Klein must be connected (klein.connect()) before querying a model')
         
         if (this.args.default_scope) {
             return this.args.default_scope;
@@ -101,7 +101,7 @@ class Model {
     
     
     destroy (model, options) {
-        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before destroying a model')
+        if (!this.hasKnex()) throw new Error('Klein must be connected (klein.connect()) before destroying a model')
 
         return new Promise((resolve, reject) => {
             this.knex(this.table_name).where({ id: model.get('id') }).del().then(() => {
@@ -129,7 +129,7 @@ class Model {
     
     
     save (model, options) {
-        if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before saving a model')
+        if (!this.hasKnex()) throw new Error('Klein must be connected (klein.connect()) before saving a model')
 
         if (typeof options === "undefined") options = {};
         

--- a/model.js
+++ b/model.js
@@ -60,9 +60,9 @@ class Model {
         if (!this.has_knex()) throw new Error('Klein must be connected (klein.connect()) before a model has access to Knex')
 
         if (options && options.transaction) {
-            return this._knex(table).transacting(options.transaction);
+            return this.klein.knex(table).transacting(options.transaction);
         } else {
-            return this._knex(table);
+            return this.klein.knex(table);
         }
     }
 

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -8,6 +8,7 @@ Log.silent = true;
 const Helpers = require('./helpers');
 
 const Klein = require('../auto');
+const DisconnectedKlein = Klein.create()
 
 
 test('It can build independent queries', t => {
@@ -37,6 +38,16 @@ test('It can build independent queries', t => {
     const where_not_null = Users.whereNotNull('name').toString();
     t.is(where_not_null, `select * from "users" where "name" is not null`);
 });
+
+test('It throws an error when building independent queries without being connected', t => {
+    const Users = DisconnectedKlein.model('users')
+
+    const expected_error = /Klein must be connected/
+
+    t.throws(() => {
+        Users.where({ email: 'test@test.com'})
+    }, expected_error)
+})
 
 
 test.serial('It can create a new instance', t => {
@@ -116,6 +127,43 @@ test.serial('It can save/restore/destroy an instance', t => {
         });
     });
 });
+
+test('It throws when saving/restoring/destroying instances without being connected', t => {
+    const Lists = DisconnectedKlein.model('lists')
+
+    const expected_error = /Klein must be connected/
+
+    const new_list = {
+        name: 'Todo', 
+        tasks: ['first', 'second', 'third'] 
+    }
+
+    const saved_list = Immutable.Map({
+        id: uuid(),
+        name: 'Todo', 
+        tasks: ['first', 'second', 'third']    
+    })
+
+    t.throws(() => {
+        Lists.create(new_list)
+    }, expected_error)
+
+    t.throws(() => {
+        Lists.find('some-id')
+    }, expected_error)
+
+    t.throws(() => {
+        Lists.save(saved_list)
+    }, expected_error)
+
+    t.throws(() => {
+        Lists.destroy(saved_list)
+    }, expected_error)
+
+    t.throws(() => {
+        Lists.reload(saved_list)
+    }, expected_error)
+})
 
 
 test.serial('It can save/restore a collection', t => {


### PR DESCRIPTION
A model should be able to be defined without requiring a database connection to be instantiated / connected. In most applications, you want to control when the code connects to the database, so you can implement proper management of the connection, error handling, logging, retrying the connection, etc. 

This **backwards-compatible** change (all unit tests passing without alterations) allows for that.

```js
const Klein = require('klein');

const User = Klein.model('users');

// in server / app bootup time

Klein.connect()
// or 
const db = Knex({})
// add error handling on the Knex connection pool, etc.
Klein.connect(db)
```

Any attempt to call query, save or destroy users without first connecting will throw an error explaining `connect()` must be called first, even in the cases where a Promise is returned. Why? This is not some runtime error that's recoverable, but more a developer warning they have hooked up something incorrectly. Personally, in cases like that, I won't my app to blow up as early and loudly as possible.

There's one bit of API I've added, but it's optional. It's to break out of the singleton and uses multiple db's / be strict about dependency injection. Perhaps that should be a separate PR, but it seemed appropriate.

```
const Klein = require('klein') // returns singleton instance
const otherKlein = Klein.create()
```

I've yet to write any additional tests to cover the new behaviour of Errors being thrown, but I wanted to get a feel for the chance of this getting merged before investing that time.