### PR TITLE
Add support for 'has-one' relations

### DIFF
--- a/model.js
+++ b/model.js
@@ -58,6 +58,12 @@ class Model {
                 relation.table = relation.table || Inflect.pluralize(relation.has_many);
                 relation.key = relation.foreign_key || `${Inflect.singularize(this.table_name)}_id`;
                 relation.dependent = relation.dependent === true;
+            } else if (relation.has_one) {
+                relation.many = false;
+                relation.type = 'has_one';
+                relation.table = relation.table || Inflect.pluralize(relation.has_one);
+                relation.key = relation.foreign_key || `${Inflect.singularize(this.table_name)}_id`;
+                relation.dependent = relation.dependent === true;
             }
 
             this._available_relations[relation_name] = relation;

--- a/test/model-relations-test.js
+++ b/test/model-relations-test.js
@@ -845,8 +845,6 @@ test('It can destroy dependent objects when destroying the parent', t => {
                 .set('profile', profile);
 
             return Users.create(new_user).then(user => {
-                console.log(new_user)
-
                 return Users.destroy(user).then(user => {
                     return Promise.all([
                         Projects.reload(project),


### PR DESCRIPTION
While using Klein in a slightly bigger data model, the need arised for a 'has-one' relationship. In behaviour it's not unlike a 'has-many', but operating on a single row rather than multiple. The foreign key lives on the table of the relation, which would define a 'belongs_to' relation.

I tried to follow the style of the original implementation and tests, but let me know if anything needs adjusting.