### PR TITLE
Improve interop with Vry by allowing custom instances

### DIFF
--- a/__tests__/model-test.js
+++ b/__tests__/model-test.js
@@ -84,6 +84,31 @@ describe('Instances', () => {
     expect(list.get('tasks').count()).toBe(newList.tasks.length);
   });
 
+  test('It can create a custom new instance through a custom factory', async () => {
+    process.env.APP_ROOT = '/tmp/klein/new-instance-custom-factory';
+    FS.removeSync(process.env.APP_ROOT);
+
+    await Helpers.setupDatabase([['list', 'name:string', 'tasks:jsonb']], { knex: Klein.knex });
+
+    const customInstance = Immutable.Map({ something: 'else' })
+
+    const newList = {
+      name: 'Todo',
+      tasks: ['first', 'second', 'third']
+    };
+
+    const Lists = Klein.model('lists', { 
+      factory: (instance) => {
+        expect(instance.get('name')).toBe(newList.name);
+        return customInstance;
+      }
+    });
+
+    let list = await Lists.create(newList);
+
+    expect(customInstance.equals(list)).toBe(true);
+  });
+
   test('It can save/restore/destroy an instance', async () => {
     const Lists = Klein.model('lists');
 
@@ -120,6 +145,51 @@ describe('Instances', () => {
     list = await Lists.reload(deletedList);
     expect(list).toBeNull();
   });
+
+  test('It can save/restore/destroy a custom instance', async () => {
+    process.env.APP_ROOT = '/tmp/klein/save-and-restore-custom-instance';
+    FS.removeSync(process.env.APP_ROOT);
+
+    const newList = {
+      name: 'Todo',
+      tasks: ['first', 'second', 'third']
+    };
+
+    const Lists = Klein.model('lists', { 
+      factory: (instance) => {
+        return instance.set('__typeName', 'list');
+      },
+      serialize: (customInstance) => {
+        return customInstance.remove('__typeName').toJS()
+      },
+      instanceOf: (maybeInstance) => {
+        return maybeInstance && maybeInstance.toJS && maybeInstance.get('__typeName') === 'list';
+      }
+    });
+
+    await Helpers.setupDatabase([['list', 'name:string', 'tasks:jsonb']], { knex: Klein.knex });
+
+    let list = await Lists.create(newList);
+
+    list = await Lists.find(list.get('id'));
+    expect(list.get('__typeName')).toBe('list');
+
+    list = list.set('name', 'New Name');
+    list = list.set('tasks', list.get('tasks').push('fourth'));
+    list = await Lists.save(list);
+    
+    list = await Lists.where({ name: 'New Name' }).first();
+
+    expect(list.get('name')).toBe('New Name');
+    expect(list.get('tasks').count()).toBe(newList.tasks.length + 1);
+    expect(list.get('tasks').last()).toBe('fourth');
+    expect(list.get('__typeName')).toBe('list');
+
+    let deletedList = await Lists.destroy(list);
+
+    list = await Lists.reload(deletedList);
+    expect(list).toBeNull();
+  })
 
   test('It throws when saving/restoring/destroying instances without being connected', async () => {
     const Lists = DisconnectedKlein.model('lists');

--- a/model.js
+++ b/model.js
@@ -1,6 +1,7 @@
 const Immutable = require('immutable');
 const Inflect = require('i')();
 const uuid = require('uuid/v4');
+const _isPlainObject = require('lodash.isplainobject');
 
 class Model {
   /**
@@ -195,7 +196,7 @@ class Model {
 
     if (typeof options === 'undefined') options = {};
 
-    let properties = model.toJS ? model.toJS() : Object.assign({}, model);
+    let properties = Object.assign({}, this._serialize(model));
 
     // Detach relations because they can't be saved against this record
     let relations = {};
@@ -207,7 +208,7 @@ class Model {
     });
 
     // Convert everything to something we can put into the database
-    properties = this._serialize(properties);
+    properties = this._prepareFields(properties);
     this._updateTimestamp(properties, 'updatedAt');
 
     // Check if the record has already been persisted
@@ -258,7 +259,7 @@ class Model {
       this._hook('afterCreate', object);
     }
 
-    return Immutable.fromJS(object);
+    return this._factory(object);
   }
 
   /**
@@ -371,7 +372,7 @@ class Model {
       return this._includeRelations(results, options).then(results => {
         let result = Object.assign({}, results[0]);
 
-        return Immutable.fromJS(result);
+        return this._factory(result);
       });
     });
   }
@@ -392,7 +393,7 @@ class Model {
       results = results.map(r => Object.assign({}, r));
 
       return this._includeRelations(results, options).then(results => {
-        return Immutable.fromJS(results);
+        return this._factory(results);
       });
     });
   }
@@ -530,12 +531,59 @@ class Model {
   }
 
   /**
+   * Create instance of the model
+   * @param {Object} properties
+   * @returns {Model}
+   */
+  _factory(properties) {
+    const immutable = Immutable.fromJS(properties);
+    
+    if (typeof this.args.factory === 'function') {
+      return this.args.factory(immutable);
+    } else {
+      return immutable;
+    }
+  }
+
+  /**
+   * Serialize model to plain object
+   * @param {Model|Object}
+   * @return {Object}
+   */
+  _serialize(model) {
+    if (!this._instanceOf(model)) return model;
+
+    if (typeof this.args.serialize === 'function') {
+      let result = this.args.serialize(model);
+      if (!_isPlainObject(result)) {
+        throw new Error(`serialize of '${this.tableName}' Klein.model must return a plain object`);
+      }
+      return result;
+    } else {
+      return model.toJS();
+    }
+  }
+
+  /**
+   * Determine whether the given object is considered an instance of the model
+   * @param {Immutable.Map|Object}
+   * @return {boolean}
+   */
+  _instanceOf(maybeModel) {
+    if (typeof this.args.instanceOf === 'function') {
+      return !!this.args.instanceOf(maybeModel);
+    } else {
+      return !!maybeModel.toJS;
+    }
+  }
+
+  /**
    * Create a clone of an Immutable Map or JSON Object as a JSON Object with stringified JSON fields
    * @param {Immutable.Map|Object} model 
    * @returns {Object}
    */
-  _serialize(model) {
-    let properties = model.toJS ? model.toJS() : Object.assign({}, model);
+  _prepareFields(model) {
+    let properties = Object.assign({}, this._serialize(model))
 
     if (typeof properties.id === 'undefined') {
       if (typeof this.args.generateId === 'function') {
@@ -595,7 +643,7 @@ class Model {
    * @returns {Object} The serialized model
    */
   async _saveRelations(model, options) {
-    let properties = model.toJS ? model.toJS() : model;
+    let properties = this._serialize(model);
 
     const propertiesThatAreRelations = Object.keys(properties).filter(p =>
       Object.keys(this._availableRelations).includes(p)
@@ -647,7 +695,7 @@ class Model {
    * @param {Object} options 
    */
   async _saveHasManyRelation(model, relation, relatedObjects, options) {
-    model = model.toJS ? model.toJS() : model;
+    model = this._serialize(model);
 
     // Get or make a Klein Model for the related table
     const RelatedModel = this.klein.model(relation.table);
@@ -693,7 +741,7 @@ class Model {
    * @param {Object} options eg. options.transaction
    */
   async _saveBelongsToRelation(model, relation, relatedObject, options) {
-    model = model.toJS ? model.toJS() : model;
+    model = this._serialize(model);
 
     const RelatedModel = this.klein.model(relation.table);
     const object = await RelatedModel.save(relatedObject);
@@ -719,7 +767,7 @@ class Model {
    * @param {Object} options eg. options.transaction
    */
   async _saveHasAndBelongsToManyRelation(model, relation, relatedObjects, options) {
-    model = model.toJS ? model.toJS() : model;
+    model = this._serialize(model);
 
     const RelatedModel = this.klein.model(relation.table);
 
@@ -787,7 +835,7 @@ class Model {
    * @param {Object} options eg. options.transaction
    */
   async _saveHasOneRelation(model, relation, relatedObject, options) {
-    model = model.toJS ? model.toJS() : model;
+    model = this._serialize(model);
 
     // Get or make a Klein model for the related table
     const RelatedModel = this.klein.model(relation.table);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "i": "^0.3.6",
     "immutable": "^3.8.2",
     "knex": "^0.14.6",
+    "lodash.isplainobject": "^4.0.6",
     "pg": "^7.3.0",
     "prettier": "^1.7.4",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Klein is really great for retrieving and writing Immutable data structures from Postgres. Because instances of models are just `Immutable.Map`s the work really well with other tools.,

[Vry](https://github.com/JaapRood/vry) should be the perfect match for it, allowing the definitions of  in-memory types, of which instances are also represented by `Immutable.Map`s. It allows for great dealing with type checking, merging, nested entities, applying defaults, schemas, etc. I've used them in multiple projects both in browser to server, representing derived data, resources, client models, server models, etc.

However, even though they both speak `Immutable`, using the two together is pretty tricky. Trying to get `Klein` to emit Vry "instances" seems like just chaining their factories to promises, but this is tricky with methods that _may_ return an instace, or not, or a collection of them.

By allowing custom definitions of `factory`, `serialize` and `instanceOf`, interoperation is greatly improved, allowing transformations to be applied exactly when required. These methods make up the basic interface that every Vry type is based on. The_ default behaviour hasn't changed, so this should not be a breaking change.

The result is that the two can be combined as much as the user wants, for example (not really showing off the power of Vry, just to keep things simple!):

```js
var Post = Vry.Model.create({
  typeName: 'post',
  defaults: {
    title: 'New post'
  }
)

var Posts = Klein.model('posts', {
  defaults: Post.defaults(),
  factory: Post.factory,
  serialize: Post.serialize,
  instanceOf: Post.instanceOf
})

var post = await Posts.create()
Post.instanceOf(post) // true

var posts = await Posts.all()
Post.collectionOf(posts) // true
```

Alternatively (not yet implemented) we could make these arguments part of an `instance` prop, making things even neater:

```js
var Post = Vry.Model.create({
  typeName: 'post',
  defaults: {
    title: 'New post'
  }
)

var Posts = Klein.model('posts', {
  defaults: Post.defaults(),
  instance: Post
})
```