### PR TITLE
Revert "Improve interop with Vry by allowing custom instances"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "i": "^0.3.6",
     "immutable": "^3.8.2",
     "knex": "^0.14.6",
-    "lodash.isplainobject": "^4.0.6",
     "pg": "^7.3.0",
     "prettier": "^1.7.4",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Reverts nathanhoad/klein#9, as it wasn't ready for merging yet and I'm being pulled elsewhere for now. 

To complete this approach, the API needs to be refined and the behaviour around `hooks` + `context` needs to be considered and tested.