### PR TITLE
Fix bug where belongs to relations could not be unset

### DIFF
--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -695,6 +695,14 @@ test('It can save an object that has a belongsTo relations on it', async () => {
   // Check that the initialUser projects is now empty
   initialUser = await Users.include('projects').find(initialUser.get('id'));
   expect(initialUser.get('projects').count()).toBe(0);
+
+  project = project.set('user', null);
+  project = await Projects.save(project);
+  replacementUser = await Users.where({ name: replacementUser.get('name') })
+    .include('projects')
+    .first();
+  expect(project.get('user')).toBe(null);
+  expect(replacementUser.get('projects').count()).toBe(0);
 });
 
 test('It can destroy dependent objects when destroying the parent', async () => {

--- a/model.js
+++ b/model.js
@@ -696,19 +696,25 @@ class Model {
   async _saveBelongsToRelation(model, relation, relatedObject, options) {
     model = model.toJS ? model.toJS() : model;
 
-    const RelatedModel = this.klein.model(relation.table);
-    const object = await RelatedModel.save(relatedObject);
+    var foreignValue
+
+    if (relatedObject) {
+      let RelatedModel = this.klein.model(relation.table);
+      foreignValue = await RelatedModel.save(relatedObject);
+    } else {
+      foreignValue = null
+    }
 
     await this.knex(this.tableName, options)
       .where({ id: model.id })
-      .update({ [relation.key]: object.get('id') });
+      .update({ [relation.key]: foreignValue && foreignValue.get('id') });
 
     return {
       name: relation.name,
-      value: object,
+      value: foreignValue,
       // Return with the information to update the current model
       belongsToKey: relation.key,
-      belongsToValue: object.get('id')
+      belongsToValue: foreignValue && foreignValue.get('id')
     };
   }
 

--- a/model.js
+++ b/model.js
@@ -696,13 +696,13 @@ class Model {
   async _saveBelongsToRelation(model, relation, relatedObject, options) {
     model = model.toJS ? model.toJS() : model;
 
-    var foreignValue
+    var foreignValue;
 
     if (relatedObject) {
       let RelatedModel = this.klein.model(relation.table);
       foreignValue = await RelatedModel.save(relatedObject);
     } else {
-      foreignValue = null
+      foreignValue = null;
     }
 
     await this.knex(this.tableName, options)


### PR DESCRIPTION
I ran into a bug where `belongsTo` relations could not be unset, with the model trying to save a nested relation set to `null`.  Adding a test to test this case, highlighted the same problem. The fix was to only save a nested relation when it actually is set.