### PR TITLE
Improve interop with Vry by allowing custom instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "lts/*"
 services:
   - postgresql
+addons:
+  postgresql: "9.4"
 before_script:
   - psql -c 'create database klein_test;' -U postgres
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "node"
+  - "lts/*"
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database klein_test;' -U postgres
+env:
+  - DATABASE_URL=postgres://localhost:5432/klein_test?user=postgres

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Klein.model('users', {
 });
 ```
 
-For models with [custom type definition](#custom-types), the custom instances are passed to the hooks.
+For models with a [custom type definition](#custom-types), the custom instances are passed to the hooks.
 
 #### `createdAt` and `updatedAt`
 
@@ -443,6 +443,7 @@ Users.create({ name: 'Nathan' }).then(user => {
 Users.all().then(users => {
   User.collectionOf(users) // => true
 });
+```
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Klein
+# Klein 
+
+[![Build Status](https://travis-ci.com/nathanhoad/klein.svg?branch=master)](https://travis-ci.com/nathanhoad/klein)
 
 A small ORM that combines ImmutableJS and knex.
 
@@ -151,6 +153,8 @@ Klein.model('users', {
   }
 });
 ```
+
+For models with [custom type definition](#custom-types), the custom instances are passed to the hooks.
 
 #### `createdAt` and `updatedAt`
 
@@ -362,6 +366,83 @@ Klein.transaction(transaction => {
     // Something failed and both User and Hat are now rolled back
   });
 ```
+
+## Custom types
+
+By default, Klein returns `Immutable.Map` as instances with it's key and values mapped to the table's columns and values. It's possible to supply your own type definition for Klein to accept and return, as long as it can convert both ways.
+
+```javascript
+const Klein = require('klein').connect(process.env.DATABASE_URL);
+const Users = klein.model('users', {
+  type: {
+    // without defining a factory, the default `Immutable.Map` method is used
+    factory(rawProperties) {
+      // given raw properties, return the instance
+      return Immutable.fromJS(rawProperties).set('type', 'user');
+    },
+
+    // without instanceOf falls back to default of any `Immutable.Map` qualifying as an instance
+    instanceOf(maybeInstance) {
+      // return whether the given value is a valid instance
+      return Immutable.Map.isMap(maybeInstance) && maybeInstance.get('type') === 'user';
+    },
+
+    // without serialize falls back to default of converting an `Immutable.Map` to plain JS object (deeply)
+    serialize(instance, options) {
+      // `options.context` and `options.contextName` are passed. The type definition is responsible for applying
+      // the context transformations.
+
+      // return a plain javascript version with keys and values mapping to columns and values
+      return instance.remove('type').toJS()
+    }
+  }
+})
+
+Users.create({ name: 'Nathan' }).then(user => {
+  user.get('type'); // => 'user'
+});
+```
+
+Note: when using hooks, the custom type instances are passed to the hooks, instead of the default `Immutable.Map`.
+
+### Vry
+
+Instead of defining your own custom types, Klein works really well with [Vry](https://www.npmjs.com/package/vry), which allows you to easily setup your type's logic. Just like Klein it uses `Immutable.Map` for instances, but adding a bit of metadata to allow for type identification, nested types, merging, references, etc.
+
+```
+const klein = require('klein').connect(process.env.DATABASE_URL);
+const { Model } = require('vry')
+const Invariant = require('invariant')
+
+// define your single entity, with things like name and defaults
+const User = Model.create({
+  typeName: 'user',
+  defaults: {
+    name: 'Unknown user',
+    email: null
+  }
+})
+
+// add your own methods
+User.hasEmail = function(user) {
+  // make sure an actual user was passed
+  Invariant(User.instanceOf(user), 'User required to check whether user has an email')
+  
+  return !!user.get('email')
+}
+
+// Use your Vry model as a Klein type
+const Users = klein.model('users', {
+  type: User
+})
+
+Users.create({ name: 'Nathan' }).then(user => {
+  User.hasEmail(user) // => false
+});
+
+Users.all().then(users => {
+  User.collectionOf(users) // => true
+});
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Note: when using hooks, the custom type instances are passed to the hooks, inste
 
 Instead of defining your own custom types, Klein works really well with [Vry](https://www.npmjs.com/package/vry), which allows you to easily setup your type's logic. Just like Klein it uses `Immutable.Map` for instances, but adding a bit of metadata to allow for type identification, nested types, merging, references, etc.
 
-```
+```javascript
 const klein = require('klein').connect(process.env.DATABASE_URL);
 const { Model } = require('vry')
 const Invariant = require('invariant')

--- a/__tests__/__helpers__.js
+++ b/__tests__/__helpers__.js
@@ -1,5 +1,5 @@
-process.env.DATABASE_URL = 'postgres://localhost:5432/klein_test';
-process.env.TEST_DATABASE_URL = 'postgres://localhost:5432/klein_test';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://localhost:5432/klein_test';
+process.env.TEST_DATABASE_URL = process.env.TEST_DATABASE_URL || 'postgres://localhost:5432/klein_test';
 
 const Knex = require('knex');
 const Schema = require('../schema').createSchema({ log: false });

--- a/__tests__/model-test.js
+++ b/__tests__/model-test.js
@@ -569,7 +569,11 @@ describe('JSON', () => {
         return Immutable.Map.isMap(maybeInstance) && maybeInstance.get('type') === name;
       },
       serialize(instance, options) {
-        return instance.get('wrapped').set('context', options && options.context).toObject();
+        return instance.get('wrapped')
+          // note: we can't use merge here, as it will cast arrays and objects to be Immutable
+          .set('context', options && options.context)
+          .set('contextName', options && options.contextName)
+          .toObject();
       }
     });
 
@@ -616,19 +620,24 @@ describe('JSON', () => {
     const json1 = Users.json(user, 'special')
     expect(json1.context).toBe(specialContext)
     expect(json1.isSpecial).toBeUndefined()
+    expect(json1.contextName).toEqual('special')
 
     const json2 = Users.json(user, specialContext)
     expect(json2.context).toBe(specialContext)
+    expect(json2.contextName).toBeNull()
 
     const json3 = Users.json(user, 'simple')
     expect(json3.context).toEqual(['firstName', 'lastName'])
+    expect(json3.contextName).toEqual('simple')
 
     const json4 = Users.json(user, 'everything')
     expect(json4.context).toEqual('*')
+    expect(json4.contextName).toEqual('everything')
 
     const json5 = Hats.json(hat, 'simple')
     expect(json5.type).toEqual(hat.get('type'))
     expect(json5.user.context).toEqual(['firstName', 'lastName'])
+    expect(json5.user.contextName).toEqual('simple')
   })
 });
 

--- a/__tests__/model-test.js
+++ b/__tests__/model-test.js
@@ -84,6 +84,31 @@ describe('Instances', () => {
     expect(list.get('tasks').count()).toBe(newList.tasks.length);
   });
 
+  test('It can create a custom new instance through a custom factory', async () => {
+    process.env.APP_ROOT = '/tmp/klein/new-instance-custom-factory';
+    FS.removeSync(process.env.APP_ROOT);
+
+    await Helpers.setupDatabase([['list', 'name:string', 'tasks:jsonb']], { knex: Klein.knex });
+
+    const customInstance = Immutable.Map({ something: 'else' })
+
+    const newList = {
+      name: 'Todo',
+      tasks: ['first', 'second', 'third']
+    };
+
+    const Lists = Klein.model('lists', { 
+      factory: (instance) => {
+        expect(instance.get('name')).toBe(newList.name);
+        return customInstance;
+      }
+    });
+
+    let list = await Lists.create(newList);
+
+    expect(customInstance.equals(list)).toBe(true);
+  });
+
   test('It can save/restore/destroy an instance', async () => {
     const Lists = Klein.model('lists');
 
@@ -120,6 +145,51 @@ describe('Instances', () => {
     list = await Lists.reload(deletedList);
     expect(list).toBeNull();
   });
+
+  test('It can save/restore/destroy a custom instance', async () => {
+    process.env.APP_ROOT = '/tmp/klein/save-and-restore-custom-instance';
+    FS.removeSync(process.env.APP_ROOT);
+
+    const newList = {
+      name: 'Todo',
+      tasks: ['first', 'second', 'third']
+    };
+
+    const Lists = Klein.model('lists', { 
+      factory: (instance) => {
+        return instance.set('__typeName', 'list');
+      },
+      serialize: (customInstance) => {
+        return customInstance.remove('__typeName').toJS()
+      },
+      instanceOf: (maybeInstance) => {
+        return maybeInstance && maybeInstance.toJS && maybeInstance.get('__typeName') === 'list';
+      }
+    });
+
+    await Helpers.setupDatabase([['list', 'name:string', 'tasks:jsonb']], { knex: Klein.knex });
+
+    let list = await Lists.create(newList);
+
+    list = await Lists.find(list.get('id'));
+    expect(list.get('__typeName')).toBe('list');
+
+    list = list.set('name', 'New Name');
+    list = list.set('tasks', list.get('tasks').push('fourth'));
+    list = await Lists.save(list);
+    
+    list = await Lists.where({ name: 'New Name' }).first();
+
+    expect(list.get('name')).toBe('New Name');
+    expect(list.get('tasks').count()).toBe(newList.tasks.length + 1);
+    expect(list.get('tasks').last()).toBe('fourth');
+    expect(list.get('__typeName')).toBe('list');
+
+    let deletedList = await Lists.destroy(list);
+
+    list = await Lists.reload(deletedList);
+    expect(list).toBeNull();
+  })
 
   test('It throws when saving/restoring/destroying instances without being connected', async () => {
     const Lists = DisconnectedKlein.model('lists');

--- a/__tests__/model-test.js
+++ b/__tests__/model-test.js
@@ -560,7 +560,7 @@ describe('JSON', () => {
     expect(user.has('updatedAt')).toBeFalsy();
   });
 
-  test('It defers the context to the custom type of a model', () => {
+  test('It defers the rendering of the context to the custom type of a model', () => {
     const testType = (name) => ({
       factory(props) {
         return Immutable.Map({ type: name, wrapped: Immutable.fromJS(props) });
@@ -588,6 +588,15 @@ describe('JSON', () => {
       }
     });
 
+    const Hats = Klein.model('hats', {
+      contexts: {
+        simple: ['type', 'user']
+      },
+      relations: {
+        user: { belongsTo: 'users' }
+      }
+    });
+
     const user = Immutable.fromJS({
       type: 'user',
       wrapped: {
@@ -598,12 +607,28 @@ describe('JSON', () => {
       }
     });
 
+    const hat = Immutable.fromJS({
+      type: 'cowboy',
+      size: 'L',
+      user: user
+    })
+
     const json1 = Users.json(user, 'special')
-    expect(json1.context).toBe('special')
+    expect(json1.context).toBe(specialContext)
     expect(json1.isSpecial).toBeUndefined()
 
     const json2 = Users.json(user, specialContext)
     expect(json2.context).toBe(specialContext)
+
+    const json3 = Users.json(user, 'simple')
+    expect(json3.context).toEqual(['firstName', 'lastName'])
+
+    const json4 = Users.json(user, 'everything')
+    expect(json4.context).toEqual('*')
+
+    const json5 = Hats.json(hat, 'simple')
+    expect(json5.type).toEqual(hat.get('type'))
+    expect(json5.user.context).toEqual(['firstName', 'lastName'])
   })
 });
 

--- a/__tests__/model-test.js
+++ b/__tests__/model-test.js
@@ -84,7 +84,7 @@ describe('Instances', () => {
     expect(list.get('tasks').count()).toBe(newList.tasks.length);
   });
 
-  test('It can create a custom new instance through a custom factory', async () => {
+  test('It can create a custom new instance through a custom type factory', async () => {
     process.env.APP_ROOT = '/tmp/klein/new-instance-custom-factory';
     FS.removeSync(process.env.APP_ROOT);
 
@@ -98,9 +98,11 @@ describe('Instances', () => {
     };
 
     const Lists = Klein.model('lists', { 
-      factory: (instance) => {
-        expect(instance.get('name')).toBe(newList.name);
-        return customInstance;
+      type: {
+        factory: (instance) => {
+          expect(instance.get('name')).toBe(newList.name);
+          return customInstance;
+        }
       }
     });
 
@@ -146,7 +148,7 @@ describe('Instances', () => {
     expect(list).toBeNull();
   });
 
-  test('It can save/restore/destroy a custom instance', async () => {
+  test('It can save/restore/destroy an instance of custom type', async () => {
     process.env.APP_ROOT = '/tmp/klein/save-and-restore-custom-instance';
     FS.removeSync(process.env.APP_ROOT);
 
@@ -155,15 +157,17 @@ describe('Instances', () => {
       tasks: ['first', 'second', 'third']
     };
 
-    const Lists = Klein.model('lists', { 
-      factory: (instance) => {
-        return instance.set('__typeName', 'list');
-      },
-      serialize: (customInstance) => {
-        return customInstance.remove('__typeName').toJS()
-      },
-      instanceOf: (maybeInstance) => {
-        return maybeInstance && maybeInstance.toJS && maybeInstance.get('__typeName') === 'list';
+    const Lists = Klein.model('lists', {
+      type: {
+        factory: (instance) => {
+          return instance.set('__typeName', 'list');
+        },
+        serialize: (customInstance) => {
+          return customInstance.remove('__typeName').toJS()
+        },
+        instanceOf: (maybeInstance) => {
+          return maybeInstance && maybeInstance.toJS && maybeInstance.get('__typeName') === 'list';
+        }
       }
     });
 
@@ -769,11 +773,13 @@ describe('Hooks', () => {
 
   test('It is compatible with custom types', async () => {
     const Lists = Klein.model('lists', {
-      factory: (instance) => {
-        return Immutable.Map({ custom: true, wrapped: Immutable.fromJS(instance) })
-      },
-      serialize: (instance) => {
-        return instance.get('wrapped').toJS()
+      type: {
+        factory: (instance) => {
+          return Immutable.Map({ custom: true, wrapped: Immutable.fromJS(instance) })
+        },
+        serialize: (instance) => {
+          return instance.get('wrapped').toJS()
+        }
       },
       hooks: {
         beforeCreate(model) {

--- a/model.js
+++ b/model.js
@@ -538,8 +538,8 @@ class Model {
   _factory(properties) {
     const immutable = Immutable.fromJS(properties);
     
-    if (typeof this.args.factory === 'function') {
-      return this.args.factory(immutable);
+    if (this.args.type && typeof this.args.type.factory === 'function') {
+      return this.args.type.factory(immutable);
     } else {
       return immutable;
     }
@@ -553,8 +553,8 @@ class Model {
   _serialize(model) {
     if (!this._instanceOf(model)) return model;
 
-    if (typeof this.args.serialize === 'function') {
-      let result = this.args.serialize(model);
+    if (this.args.type && typeof this.args.type.serialize === 'function') {
+      let result = this.args.type.serialize(model);
       if (!_isPlainObject(result)) {
         throw new Error(`serialize of '${this.tableName}' Klein.model must return a plain object`);
       }
@@ -570,8 +570,8 @@ class Model {
    * @return {boolean}
    */
   _instanceOf(maybeModel) {
-    if (typeof this.args.instanceOf === 'function') {
-      return !!this.args.instanceOf(maybeModel);
+    if (this.args.type && typeof this.args.type.instanceOf === 'function') {
+      return !!this.args.type.instanceOf(maybeModel);
     } else {
       return !!maybeModel.toJS;
     }

--- a/model.js
+++ b/model.js
@@ -393,7 +393,7 @@ class Model {
       results = results.map(r => Object.assign({}, r));
 
       return this._includeRelations(results, options).then(results => {
-        return this._factory(results);
+        return Immutable.List(results.map((r) => this._factory(r)));
       });
     });
   }

--- a/model.js
+++ b/model.js
@@ -532,9 +532,10 @@ class Model {
     const context = !options.context ? null :
       options.context instanceof Function ? options.context :
       this.contexts[options.context]
+    const contextName = options.context && typeof options.context === 'string' ? options.context : null
 
     if (this.args.type && typeof this.args.type.serialize === 'function') {
-      let result = this.args.type.serialize(model, { ...options, context });
+      let result = this.args.type.serialize(model, { ...options, context, contextName });
       return verifyResult(result);
     }
 

--- a/model.js
+++ b/model.js
@@ -621,7 +621,7 @@ class Model {
     if (typeof hookFn !== 'function') return properties;
 
     // Convert to Immutable for the hook
-    properties = await hookFn(properties.toJS ? properties : Immutable.fromJS(properties), extraInfo);
+    properties = await hookFn(this._instanceOf(properties) ? properties : this._factory(properties), extraInfo);
 
     // beforeCreate and beforeSave must return something
     if (typeof properties !== 'object' && ['beforeSave', 'beforeCreate'].includes(hook)) {
@@ -630,7 +630,7 @@ class Model {
 
     if (typeof properties === 'object') {
       // Convert back to raw to give back to the model
-      return properties.toJS ? properties.toJS() : properties;
+      return this._serialize(properties);
     }
 
     return true;

--- a/model.js
+++ b/model.js
@@ -551,14 +551,18 @@ class Model {
    * @return {Object}
    */
   _serialize(model) {
-    if (!this._instanceOf(model)) return model;
-
-    if (this.args.type && typeof this.args.type.serialize === 'function') {
-      let result = this.args.type.serialize(model);
+    const verifyResult = (result) => {
       if (!_isPlainObject(result)) {
         throw new Error(`serialize of '${this.tableName}' Klein.model must return a plain object`);
       }
       return result;
+    }
+    
+    if (!this._instanceOf(model)) return verifyResult(model);
+
+    if (this.args.type && typeof this.args.type.serialize === 'function') {
+      let result = this.args.type.serialize(model);
+      return verifyResult(result);
     } else {
       return model.toJS();
     }

--- a/model.js
+++ b/model.js
@@ -846,6 +846,7 @@ class Model {
 
     // Get or make a Klein model for the related table
     const RelatedModel = this.klein.model(relation.table);
+    relatedObject = RelatedModel._serialize(relatedObject);
 
     // find any objects that have already been persisted
     let newRelatedObjectsIds = [relatedObject].map(r => r.id).filter(id => id && typeof id !== 'undefined');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5632,6 +5632,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "i": "^0.3.6",
     "immutable": "^3.8.2",
     "knex": "^0.14.6",
+    "lodash.isplainobject": "^4.0.6",
     "pg": "^7.3.0",
     "prettier": "^1.7.4",
     "uuid": "^3.1.0",


### PR DESCRIPTION
A follow-up attempt after we reverted #9 for being incomplete. To remind ourselves, this is the pitch from the original pull request:

> [Vry](https://github.com/JaapRood/vry) should be the perfect match for it, allowing the definitions of  in-memory types, of which instances are also represented by `Immutable.Map`s. It allows for great dealing with type checking, merging, nested entities, applying defaults, schemas, etc. I've used them in multiple projects both in browser to server, representing derived data, resources, client models, server models, etc.
> 
> However, even though they both speak `Immutable`, using the two together is pretty tricky. Trying to get `Klein` to emit Vry "instances" seems like just chaining their factories to promises, but this is tricky with methods that _may_ return an instace, or not, or a collection of them.
> 
> By allowing custom definitions of `factory`, `serialize` and `instanceOf`, interoperation is greatly improved, allowing transformations to be applied exactly when required. These methods make up the basic interface that every Vry type is based on. The_ default behaviour hasn't changed, so this should not be a breaking change.
> 
> The result is that the two can be combined as much as the user wants, for example (not really showing off the power of Vry, just to keep things simple!):

While still incomplete, thus far this version now deals with hooks properly, passing instances of the correct type and accepting them as results. Also, I moved the type definition functions to the `type` option, allowing types with a compatible definition (like Vry) to be referenced easily:

```js
var Post = Vry.Model.create({
  typeName: 'post',
  defaults: {
    title: 'New post'
  }
)

var Posts = Klein.model('posts', {
  type: Post,
  
  hooks: {
    beforeCreate(instance) { /* now receives the custom instance */ }
  }
})
```

Before we merge this, we need to consider the following:

- **How do custom instances deal with `context`?** Logically, how context should work is inherent to the instance type. `Vry` instances are Immutable.Map's as well, so the logic might incidentally work, but there is nothing in the interface that allows you to rely on this. We'll either want to enable that through the type definition API or throw an Error when the two are combined.
- **How do nested relation types work**. Technically, all properties including the relations are passed to `type.factory`, so we can just put that responsibility on to that (Vry does the right thing). Alternatively, we could recursively apply the types before passed to the root `factory`, but that's exactly the kind of complexity we're trying to avoid and let Vry handle. Whatever it is, it'll need to be documented.