### PR TITLE
Only use custom instance factories when hasOne or belongsTo relation is populated

### DIFF
--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -272,6 +272,10 @@ test('It can load belongsTo, hasOne, and hasMany relations for model with custom
     {
       id: uuid(),
       name: 'Gamers'
+    },
+    {
+      id: uuid(),
+      name: 'Eat Veggies'
     }
   ];
 
@@ -287,6 +291,10 @@ test('It can load belongsTo, hasOne, and hasMany relations for model with custom
     {
       name: 'Ben',
       teamId: newTeams[1].id
+    },
+    {
+      name: 'Coco',
+      teamId: null
     }
   ];
 
@@ -313,7 +321,7 @@ test('It can load belongsTo, hasOne, and hasMany relations for model with custom
   let profiles = await Profiles.create(newProfiles);
   let users = await Users.include('team').all();
 
-  expect(users.count()).toBe(3);
+  expect(users.count()).toBe(4);
 
   let nathan = users.find(u => u.getIn(['wrapped', 'name']) === 'Nathan');
   expect(nathan).toBeTruthy();
@@ -327,8 +335,12 @@ test('It can load belongsTo, hasOne, and hasMany relations for model with custom
   expect(ben).toBeTruthy();
   expect(ben.getIn(['wrapped', 'team', 'wrapped', 'name'])).toBe(newTeams[1].name);
 
+  let coco = users.find(u => u.getIn(['wrapped', 'name']) === 'Coco');
+  expect(coco).toBeTruthy();
+  expect(coco.getIn(['wrapped', 'team'])).toBeUndefined();
+
   teams = await Teams.include('users').all();
-  expect(teams.count()).toBe(2);
+  expect(teams.count()).toBe(3);
   expect(
     teams
       .find(t => t.getIn(['wrapped', 'name']) === newTeams[0].name)
@@ -344,9 +356,10 @@ test('It can load belongsTo, hasOne, and hasMany relations for model with custom
 
   teams = await Teams.include('profile').all();
 
-  expect(teams.count()).toBe(2);
+  expect(teams.count()).toBe(3);
   expect(teams.find(t => t.getIn(['wrapped', 'name']) == newTeams[0].name).getIn(['wrapped', 'profile', 'wrapped', 'bio'])).toBe(newProfiles[0].bio);
   expect(teams.find(t => t.getIn(['wrapped', 'name']) == newTeams[1].name).getIn(['wrapped', 'profile', 'wrapped', 'bio'])).toBe(newProfiles[1].bio);
+  expect(teams.find(t => t.getIn(['wrapped', 'name']) == newTeams[2].name).getIn(['wrapped', 'profile'])).toBeUndefined();
 });
 
 test('It can load hasAndBelongsToMany relations', async () => {

--- a/model.js
+++ b/model.js
@@ -959,11 +959,11 @@ class Model {
     // Graft the relations onto the matching results
     return results.map(result => {
       relations.forEach(relation => {
+        var row;
         switch (relation.properties.type) {
           case 'belongsTo':
-            result[relation.name] = relation.model._factory(
-              relation.rows.find(r => r.id === result[relation.properties.key])
-            );
+            row = relation.rows.find(r => r.id === result[relation.properties.key]);
+            result[relation.name] = row && relation.model._factory(row);
             break;
 
           case 'hasMany':
@@ -973,9 +973,8 @@ class Model {
             break;
 
           case 'hasOne':
-            result[relation.name] = relation.model._factory(
-              relation.rows.find(r => r[relation.properties.key] === result.id)
-            );
+            row = relation.rows.find(r => r[relation.properties.key] === result.id);
+            result[relation.name] = row && relation.model._factory(row);
             break;
 
           case 'hasAndBelongsToMany':


### PR DESCRIPTION
I ran into this bug while working on a project where the related instance _might_ exist, but could also be unpopulated. Rather than leaving the field `undefined`, the custom type's factory was still called, populating it with an empty instance.