### PR TITLE
Fix bug where has one relations would not be persisted when already assigned an id

### DIFF
--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -605,6 +605,11 @@ test('It can save an object that has a hasOne relation on it', async () => {
     bio: 'Working on Design'
   });
 
+  const profileWithId = Immutable.fromJS({
+    id: uuid(),
+    name: 'Working on Art'
+  });
+
   const newUser = {
     name: 'Nathan'
   };
@@ -639,6 +644,19 @@ test('It can save an object that has a hasOne relation on it', async () => {
 
   profile = await Profiles.include('user').find(profile.get('id'));
   expect(profile.get('user')).toBeFalsy();
+
+  user = user.set('profile', profileWithId);
+  user = await Users.save(user);
+
+  expect(user.getIn(['profile', 'id'])).toBe(profileWithId.get('id'));
+
+
+  let existingProfile = await Profiles.create(initialProfile)
+  user = user.set('profile', existingProfile.set('name', 'Working on updates'));
+  user = await Users.save(user)
+
+  expect(user.getIn(['profile', 'id'])).toBe(existingProfile.get('id'));
+  expect(user.getIn(['profile', 'name'])).toBe('Working on updates');
 });
 
 test('It can save an object that has a hasOne relation on it for model with custom instance', async () => {

--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -652,11 +652,11 @@ test('It can save an object that has a hasOne relation on it', async () => {
 
 
   let existingProfile = await Profiles.create(initialProfile)
-  user = user.set('profile', existingProfile.set('name', 'Working on updates'));
+  user = user.set('profile', existingProfile.set('bio', 'Working on updates'));
   user = await Users.save(user)
 
   expect(user.getIn(['profile', 'id'])).toBe(existingProfile.get('id'));
-  expect(user.getIn(['profile', 'name'])).toBe('Working on updates');
+  expect(user.getIn(['profile', 'bio'])).toBe('Working on updates');
 });
 
 test('It can save an object that has a hasOne relation on it for model with custom instance', async () => {

--- a/model.js
+++ b/model.js
@@ -872,12 +872,13 @@ class Model {
         return this.knex(relation.table, options)
           .select('id')
           .whereIn('id', newRelatedObjectsIds)
+          .then((results) => results.map((result) => result.id))
           .then(existingRelatedIds => {
             relatedObject[relation.key] = model.id;
             // save/update the related object (which will then in turn save any relations on itself)
             return RelatedModel.save(
               relatedObject,
-              Object.assign({}, options, { exists: newRelatedObjectsIds.includes(relatedObject.id) })
+              Object.assign({}, options, { exists: existingRelatedIds.includes(relatedObject.id) })
             );
           })
           .then(savedRelatedObject => {


### PR DESCRIPTION
I ran into a bug that is basically the same one as #11, but for `hasOne` instead of `hasMany`. When trying to save a relation that has a pre-assigned identifier but hasn't been persisted yet, the relation would never be persisted and silently skipped.

The fix is basically the same one for #11 as well, with the logic already mostly being there but needing to be hooked up.