### PR TITLE
Fix unsetting hasOne relation of a model

### DIFF
--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -657,6 +657,11 @@ test('It can save an object that has a hasOne relation on it', async () => {
 
   expect(user.getIn(['profile', 'id'])).toBe(existingProfile.get('id'));
   expect(user.getIn(['profile', 'bio'])).toBe('Working on updates');
+
+  user = user.set('profile', null);
+  user = await Users.save(user);
+
+  expect(user.get('profile')).toBeNull();
 });
 
 test('It can save an object that has a hasOne relation on it for model with custom instance', async () => {


### PR DESCRIPTION
In using the `hasOne` relation more in one of my client projects I realised that unsetting an already established relation didn't work correctly. Given that the method to save this relation wasn't ported to async / await yet, it wasn't as obvious to see why. Once I got that formatted properly, the fix was relatively simple, only updating the related model if there was an instance for it in the first place.