### PR TITLE
Fix bug where included relations of past queries would be applied to new queries

### DIFF
--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -119,6 +119,11 @@ test('It can load belongsTo, hasOne, and hasMany relations', async () => {
   expect(teams.count()).toBe(2);
   expect(teams.find(t => t.get('name') == newTeams[0].name).getIn(['profile', 'bio'])).toBe(newProfiles[0].bio);
   expect(teams.find(t => t.get('name') == newTeams[1].name).getIn(['profile', 'bio'])).toBe(newProfiles[1].bio);
+
+  teams = await Teams.where({ name: newTeams[0].name }).all();
+  expect(teams.count()).toBe(1);
+  expect(teams.first().get('users')).toBeUndefined();
+  expect(teams.first().get('profile')).toBeUndefined();
 });
 
 test('It can load belongsTo, hasOne, and hasMany relations with different keys', async () => {

--- a/model.js
+++ b/model.js
@@ -350,8 +350,9 @@ class Model {
    * Include related models
    */
   include() {
-    this.args._includedRelations = Array.from(arguments);
-    return this._chain(this.query().clone());
+    return this._chain(this.query().clone(), { 
+      _includedRelations: Array.from(arguments) 
+    });
   }
 
   /**
@@ -487,8 +488,8 @@ class Model {
    * @param {Object} query 
    * @returns {Model}
    */
-  _chain(query) {
-    const args = Object.assign({}, this.args, {
+  _chain(query, newArgs) {
+    const args = Object.assign({}, this.args, newArgs || {}, {
       defaultScope: query
     });
 


### PR DESCRIPTION
I uncovered this subtle but annoying and potentially serious bug while figuring out why #16 was triggered in my project's code in the first place. I was trying to save a relation that existed, but the model we're trying to save should never have retrieved, and thus should not be attempting to save. Even more weirdly, when running the offending test in isolation it would pass, but only fail when ran as part of the entire suite.

A long while with my tests and the V8 step debugger uncovered that `model.include` was mutating the original model instance, before cloning itself and returning that. This caused the behaviour where a new query that doesn't call `include`, but does use some other query method like `where`, would inherit the included relations from the previous call where `include` _was_ used.

Analysing the impact of this, I do believe there to have been a chance of dataloss, albeit only when the API is used in a very specific way. If the code dependent on the query would take action based on whether certain relations were available or not, which isn't totally unreasonable, it could have caused trouble. Fortunately, within Klein itself and how it manages relations (unsetting any relations set to `null`) it shouldn't have destroyed any of those accidentally.