### PR TITLE
Implement the touching of belongsTo relations that were not included in the saved model but do exist

### DIFF
--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -1404,6 +1404,17 @@ test('It can save an object and touch timestamps of existing belongsTo relations
   user = await Users.find(user.get('id'));
 
   expect(user.get('updatedAt')).toEqual(project.get('updatedAt'));
+  expect(user.get('updatedAt').valueOf()).toBeGreaterThan(previousUser.get('updatedAt').valueOf());
+
+  project = await Projects.save(project.set('user', null));
+  project = await Projects.find(project.get('id'));
+  project = await Projects.save(project);
+  
+  previousUser = user;
+  user = await Users.find(user.get('id'));
+
+  expect(user.get('updatedAt')).toEqual(previousUser.get('updatedAt'));
+
 });
 
 test('It can destroy dependent objects when destroying the parent', async () => {

--- a/__tests__/model-relations-test.js
+++ b/__tests__/model-relations-test.js
@@ -1,6 +1,7 @@
 const Immutable = require('immutable');
 const FS = require('fs-extra');
 const uuid = require('uuid/v4');
+const Sinon = require('sinon');
 
 const Helpers = require('./__helpers__');
 
@@ -1415,6 +1416,13 @@ test('It can save an object and touch timestamps of existing belongsTo relations
 
   expect(user.get('updatedAt')).toEqual(previousUser.get('updatedAt'));
 
+  project = await Projects.save(project.set('user', user));
+  user = await Users.include('projects').find(user.get('id'))
+  
+  Sinon.spy(Users, 'save');
+  user = await Users.save(user);
+  expect(Users.save.calledOnce).toBe(true);
+  Users.save.restore();
 });
 
 test('It can destroy dependent objects when destroying the parent', async () => {

--- a/model.js
+++ b/model.js
@@ -217,6 +217,9 @@ class Model {
     options.touch = typeof touch === 'number' ? new Date(touch) : 
       touch === false ? touch : new Date();
 
+    const savedModels = options._savedModels || Immutable.Set()
+    options._savedModels = savedModels.add(Immutable.Map({ tableName: this.tableName, id: properties.id }))
+
     // Convert everything to something we can put into the database
     properties = this._prepareFields(properties);
     this._updateTimestamp(properties, 'updatedAt', options.touch);
@@ -919,6 +922,11 @@ class Model {
         // Project belongs to User (eg. created_by_user_id)
         let relationId = model[relation.key];
         let RelatedModel = this.klein.model(relation.table);
+        let wasSaved = options._savedModels.includes(
+          Immutable.Map({ tableName: relation.table, id: relationId })
+        )
+
+        if (wasSaved) return null;
 
         let relatedRecord = relationId && await RelatedModel.find(relationId);
         if (!relatedRecord) return null;

--- a/model.js
+++ b/model.js
@@ -920,7 +920,8 @@ class Model {
         let relationId = model[relation.key];
         let RelatedModel = this.klein.model(relation.table);
 
-        let relatedRecord = await RelatedModel.find(relationId);
+        let relatedRecord = relationId && await RelatedModel.find(relationId);
+        if (!relatedRecord) return null;
         await RelatedModel.save(relatedRecord, Object.assign({}, options, { exists: true }));
       } else {
         return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,49 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
       "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
     },
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "type-detect": "4.0.8"
       }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "abab": {
       "version": "1.0.4",
@@ -383,6 +419,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-slice": {
@@ -5456,9 +5498,10 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
@@ -5627,11 +5670,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -5646,9 +5684,10 @@
       }
     },
     "lolex": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
+      "integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -5986,15 +6025,24 @@
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
     },
     "nise": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.1.tgz",
-      "integrity": "sha512-9JX3YwoIt3kS237scmSSOpEv7vCukVzLfwK0I0XhocDSHUANid8ZHnLEULbbSkfeMn98B2y5kphIWzZUylESRQ==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
         "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
       }
     },
     "node-int64": {
@@ -6383,6 +6431,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -6390,7 +6439,8 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         }
       }
     },
@@ -6806,11 +6856,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
-    },
     "sane": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
@@ -7133,33 +7178,37 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.0.tgz",
-      "integrity": "sha512-mKJCMMwRKAPEbM48tgT7rea9+Dos5xugEpVXGwMDCSRtPxF6ZjIBO+WrbixxJ0xcYJ6ZMS3/veTAI7XTW010yA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
         "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.4.2",
-        "nise": "^1.3.3",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
         "diff": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7489,11 +7538,6 @@
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.4.tgz",
       "integrity": "sha512-j4samMCQCP5+6Il9/cxCqBd3x4vvlLeVdoyGex0KixPKl4F8LpNbDSC6NDhjianZgUngElRr9UI1ryZqJDhwGg=="
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7644,7 +7688,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -8350,7 +8395,6 @@
         "mkdirp": "^0.5.1",
         "pinkie-promise": "^2.0.1",
         "rimraf": "^2.4.4",
-        "sinon": "^5.0.7",
         "yeoman-environment": "^2.0.0",
         "yeoman-generator": "^2.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "yeoman-test": "^1.7.2"
   },
   "devDependencies": {
-    "jest": "^21.2.1"
+    "jest": "^21.2.1",
+    "sinon": "^7.3.2"
   }
 }


### PR DESCRIPTION
In our project we're trying to get `updatedAt` to work correctly when used across relations. The first step to this was #18, but there is one major usecase that isn't covered by this: propagating `updatedAt` up the ownership chain. It looks to add the same API used by ActiveRecord, adding a `touch` option to the definition of a `belongsTo` relation, causing a "touch" up the ownership chain on every save.

To set the scene, we have an architecture roughly like `Offer` has one `Order` has one `Charge`. When the order is updated, the offer's `updatedAt` should reflect this. When the charge is updated, both order and offer should be touched, too. Why? Imagine an endpoint where we serve the list of offers that we want to sort by when something last happened to them. To support paging, the only really practical approach is to do so in the query to Postgres. While it _is_ possible to join all data together and determine the `updatedAt` there, this would require a messy and error-prone custom query. Having the timestamp updated correctly would be a lot more elegant, simple and robust.

Initially we thought that when updating the charge in the example above, we'd simple have to include the order and offer as well before we save. Using the new touch option introduced by #18, the timestamp would be propagated. However, `model.include` only works one level deep, which falls apart when the chain is longer than 2 models. Even if it included more, this means the consumer code has to be aware of the entire chain and be really careful to include it fully. 

The alternative is to go the route proposed here, taken from ActiveRecord. While they describe it in the context of a special `model.touch` method, [their explanation describes it well](https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-touch):

> If used along with belongs_to then touch will invoke touch method on associated object.
> ```ruby
>
> class Brake < ActiveRecord::Base
>   belongs_to :car, touch: true
> end
> 
> class Car < ActiveRecord::Base
>   belongs_to :corporation, touch: true
> end
>
> # triggers @brake.car.touch and @brake.car.corporation.touch
> @brake.touch
> ```

Given the opt-in, this enhancement is backwards compatible.
